### PR TITLE
fix: add link to the navbar logo for directing to the home page

### DIFF
--- a/public/cart.html
+++ b/public/cart.html
@@ -9,7 +9,7 @@
   </head>
   <body>
     <nav class="navbar">
-      <div class="nav-logo">E-Commerce Website</div>
+      <a class="nav-logo" href="./index.html">E-Commerce Website</a>
       <div class="nav-right">
         <a class="nav-orders" href="orders.html">Orders</a
         ><a href="cart.html" class="nav-cart">Cart</a>

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
 <body>
   <div class="wrapper">
     <nav class="navbar">
-      <div class="nav-logo">E-Commerce Website</div>
+      <a class="nav-logo" href="./index.html">E-Commerce Website</a>
       <div class="nav-right">
         <a class="nav-orders" href="orders.html">Orders</a><a href="cart.html" class="nav-cart">Cart</a>
         <a class="nav-products" href="products.html">Products</a>

--- a/public/orders.html
+++ b/public/orders.html
@@ -9,7 +9,7 @@
   </head>
   <body>
     <nav class="navbar">
-      <div class="nav-logo">E-Commerce Website</div>
+      <a class="nav-logo" href="./index.html">E-Commerce Website</a>
       <div class="nav-right">
         <a class="nav-orders" href="orders.html">Orders</a
         ><a href="cart.html" class="nav-cart">Cart</a>

--- a/public/style.css
+++ b/public/style.css
@@ -9,6 +9,10 @@ body {
   background-color: #f8f9fa;
 }
 
+a {
+  text-decoration: none;
+}
+
 .wrapper {
   height: 100vh;
   display: flex;


### PR DESCRIPTION
Fixes #6

## Description

#### This PR adds a clickable link to the navbar logo, allowing users to navigate back to the home page when they click on the logo. The logo was previously not linked, which could have caused confusion for users trying to return to the main page.

## Changes:
- Wrapped the navbar logo in an anchor `<a>` tag to make it clickable.
- Set the link to direct users to the root URL `/`, which leads them to the homepage.

